### PR TITLE
Rename PipeOpCalibration to PipeOpCalibrationPerFold

### DIFF
--- a/mlr-org/gallery/appliedml/2025-06-02-adv-perf-eval-calibration-mlr3-v2/index.qmd
+++ b/mlr-org/gallery/appliedml/2025-06-02-adv-perf-eval-calibration-mlr3-v2/index.qmd
@@ -211,7 +211,7 @@ The most common approach is Platt scaling, also called logistic calibration. Thi
 
 If effective, the logistic regression model estimates the probability regions where the original model is off (as shown in the diagnostic plot). For example, suppose that when the model predicts a 2% event rate, the logistic regression model estimates that it under-predicts the probability by 5% (relative to the observed data). Given this gap, new predictions are adjusted up so that the probability estimates are more in-line with the data.
 
-In `mlr3calibration`, to calibrate a learner you need a base learner (which will fit a model that is calibrated afterwards), a resampling strategy, and a calibration method (Platt, Beta or Isotonic). Initialize 1) another Naive Bayes base learner, 2) a holdout resampling object, and 3) a calibration strategy. The calibration strategy in `mlr3calibration` is implemented as `PipeOpCalibration` object. It requires the base learner (`learner`), the calibration method (`method`), and the resampling method (`rsmp`) as arguments to be initialized. Practically, we want to use the calibration strategy as learner, so we have to express the pipeline operator within `as_learner()`. After that, set `learner_cal$id <- "Platt Calibrated Learner"` for later reference.
+In `mlr3calibration`, to calibrate a learner you need a base learner (which will fit a model that is calibrated afterwards), a resampling strategy, and a calibration method (Platt, Beta or Isotonic). Initialize 1) another Naive Bayes base learner, 2) a holdout resampling object, and 3) a calibration strategy. The calibration strategy in `mlr3calibration` is implemented as `PipeOpCalibrationPerFold` object. It requires the base learner (`learner`), the calibration method (`method`), and the resampling method (`rsmp`) as arguments to be initialized. Practically, we want to use the calibration strategy as learner, so we have to express the pipeline operator within `as_learner()`. After that, set `learner_cal$id <- "Platt Calibrated Learner"` for later reference.
 
 
 <details>
@@ -220,7 +220,7 @@ In `mlr3calibration`, to calibrate a learner you need a base learner (which will
 ```{r index-011, eval = FALSE}
 learner_uncal = ...
 rsmp = ...
-learner_cal = as_learner(PipeOpCalibration$new(...))
+learner_cal = as_learner(PipeOpCalibrationPerFold$new(...))
 learner_cal$id <- "Platt Calibrated Learner"
 ```
 
@@ -229,7 +229,7 @@ learner_cal$id <- "Platt Calibrated Learner"
 <details>
 <summary>**Hint 2:**</summary>
 
-Check the documentation of `PipeOpCalibration` with `??PipeOpCalibration`.
+Check the documentation of `PipeOpCalibrationPerFold` with `??PipeOpCalibrationPerFold`.
 
 </details>
 
@@ -242,7 +242,7 @@ Check the documentation of `PipeOpCalibration` with `??PipeOpCalibration`.
 ```{r index-012}
 learner_uncal = lrn("classif.naive_bayes", predict_type = "prob")
 rsmp = rsmp("holdout")
-learner_cal = as_learner(PipeOpCalibration$new(learner = learner_uncal, method = "platt", rsmp = rsmp))
+learner_cal = as_learner(PipeOpCalibrationPerFold$new(learner = learner_uncal, method = "platt", rsmp = rsmp))
 learner_cal$id <- "Platt Calibrated Learner"
 ```
 
@@ -281,7 +281,7 @@ A different approach to calibration is to use isotonic regression. In a manner s
 ```{r index-014, eval = FALSE}
 learner_uncal = ...
 rsmp = ...
-learner_cal = as_learner(PipeOpCalibration$new(...))
+learner_cal = as_learner(PipeOpCalibrationPerFold$new(...))
 learner_cal$id <- "Isotonic Calibrated Learner"
 learner_cal$train(cells_train)
 
@@ -310,7 +310,7 @@ learner_uncal <- lrn("classif.naive_bayes", predict_type = "prob")
 rsmp = rsmp("holdout")
 
 # Train isotonic calibrator using validation predictions
-learner_cal_iso = as_learner(PipeOpCalibration$new(learner = learner_uncal, method = "isotonic", rsmp = rsmp))
+learner_cal_iso = as_learner(PipeOpCalibrationPerFold$new(learner = learner_uncal, method = "isotonic", rsmp = rsmp))
 learner_cal_iso$id <- "Isotonic Calibrated Learner"
 learner_cal_iso$train(cells_train)
 
@@ -327,7 +327,7 @@ calibrationplot(list(learner, learner_cal, learner_cal_iso), cells_test, bins = 
 
 # 3 Resamping for Calibration with mlr3
 
-`PipeOpCalibration` can be treated as any other `PipeOp` object. Therefore, we can use them within more complex tuning and pipeline constructs, i.e. in cross-validation (CV), to assess calibration methods.
+`PipeOpCalibrationPerFold` can be treated as any other `PipeOp` object. Therefore, we can use them within more complex tuning and pipeline constructs, i.e. in cross-validation (CV), to assess calibration methods.
 
 Fit 10 Naive Bayes models using 10-fold CV and calibrate each of these models using beta calibration, another calibration method.
 
@@ -339,7 +339,7 @@ Fit 10 Naive Bayes models using 10-fold CV and calibrate each of these models us
 You can use the following code skeleton, detailing the required steps:
 
 ```{r index-016, eval = FALSE}
-pipeline_cal = as_learner(PipeOpCalibration$new(learner = ...,
+pipeline_cal = as_learner(PipeOpCalibrationPerFold$new(learner = ...,
                                                 rsmp = ...,
                                                 method = ...))
 pipeline_cal$id <- "Beta Calibrated Learner"
@@ -357,7 +357,7 @@ calibrationplot(..., smooth = TRUE)
 
 ```{r index-017}
 #| eval: false
-pipeline_cal = as_learner(PipeOpCalibration$new(learner = lrn("classif.naive_bayes", predict_type = "prob"),
+pipeline_cal = as_learner(PipeOpCalibrationPerFold$new(learner = lrn("classif.naive_bayes", predict_type = "prob"),
                                                 rsmp = rsmp("cv", folds = 10),
                                                 method = "beta"))
 pipeline_cal$id <- "Beta Calibrated Learner"

--- a/mlr-org/gallery/appliedml/2025-06-02-adv-perf-eval-calibration-mlr3-v2/index.qmd
+++ b/mlr-org/gallery/appliedml/2025-06-02-adv-perf-eval-calibration-mlr3-v2/index.qmd
@@ -211,7 +211,7 @@ The most common approach is Platt scaling, also called logistic calibration. Thi
 
 If effective, the logistic regression model estimates the probability regions where the original model is off (as shown in the diagnostic plot). For example, suppose that when the model predicts a 2% event rate, the logistic regression model estimates that it under-predicts the probability by 5% (relative to the observed data). Given this gap, new predictions are adjusted up so that the probability estimates are more in-line with the data.
 
-In `mlr3calibration`, to calibrate a learner you need a base learner (which will fit a model that is calibrated afterwards), a resampling strategy, and a calibration method (Platt, Beta or Isotonic). Initialize 1) another Naive Bayes base learner, 2) a holdout resampling object, and 3) a calibration strategy. The calibration strategy in `mlr3calibration` is implemented as `PipeOpCalibrationPerFold` object. It requires the base learner (`learner`), the calibration method (`method`), and the resampling method (`rsmp`) as arguments to be initialized. Practically, we want to use the calibration strategy as learner, so we have to express the pipeline operator within `as_learner()`. After that, set `learner_cal$id <- "Platt Calibrated Learner"` for later reference.
+In `mlr3calibration`, to calibrate a learner you need a base learner (which will fit a model that is calibrated afterwards), a resampling strategy, and a calibration method (Platt, Beta or Isotonic). Initialize 1) another Naive Bayes base learner, 2) a holdout resampling object, and 3) a calibration strategy. The calibration strategy in `mlr3calibration` is implemented as `PipeOpCalibrationPerFold` object. It requires the base learner (`learner`), the calibration method (`method`), and the resampling method (`resampling`) as arguments to be initialized. Practically, we want to use the calibration strategy as learner, so we have to express the pipeline operator within `as_learner()`. After that, set `learner_cal$id <- "Platt Calibrated Learner"` for later reference.
 
 
 <details>
@@ -242,7 +242,7 @@ Check the documentation of `PipeOpCalibrationPerFold` with `??PipeOpCalibrationP
 ```{r index-012}
 learner_uncal = lrn("classif.naive_bayes", predict_type = "prob")
 rsmp = rsmp("holdout")
-learner_cal = as_learner(PipeOpCalibrationPerFold$new(learner = learner_uncal, method = "platt", rsmp = rsmp))
+learner_cal = as_learner(PipeOpCalibrationPerFold$new(learner = learner_uncal, method = "platt", resampling = rsmp))
 learner_cal$id <- "Platt Calibrated Learner"
 ```
 
@@ -310,7 +310,7 @@ learner_uncal <- lrn("classif.naive_bayes", predict_type = "prob")
 rsmp = rsmp("holdout")
 
 # Train isotonic calibrator using validation predictions
-learner_cal_iso = as_learner(PipeOpCalibrationPerFold$new(learner = learner_uncal, method = "isotonic", rsmp = rsmp))
+learner_cal_iso = as_learner(PipeOpCalibrationPerFold$new(learner = learner_uncal, method = "isotonic", resampling = rsmp))
 learner_cal_iso$id <- "Isotonic Calibrated Learner"
 learner_cal_iso$train(cells_train)
 
@@ -340,7 +340,7 @@ You can use the following code skeleton, detailing the required steps:
 
 ```{r index-016, eval = FALSE}
 pipeline_cal = as_learner(PipeOpCalibrationPerFold$new(learner = ...,
-                                                rsmp = ...,
+                                                resampling = ...,
                                                 method = ...))
 pipeline_cal$id <- "Beta Calibrated Learner"
 pipeline_cal$...
@@ -358,7 +358,7 @@ calibrationplot(..., smooth = TRUE)
 ```{r index-017}
 #| eval: false
 pipeline_cal = as_learner(PipeOpCalibrationPerFold$new(learner = lrn("classif.naive_bayes", predict_type = "prob"),
-                                                rsmp = rsmp("cv", folds = 10),
+                                                resampling = rsmp("cv", folds = 10),
                                                 method = "beta"))
 pipeline_cal$id <- "Beta Calibrated Learner"
 pipeline_cal$train(cells_train)

--- a/mlr-org/gallery/appliedml/2025-06-02-adv-perf-eval-calibration-mlr3/index.qmd
+++ b/mlr-org/gallery/appliedml/2025-06-02-adv-perf-eval-calibration-mlr3/index.qmd
@@ -124,7 +124,7 @@ The model is not well-calibrated. For predicted probabilities from 0 to 0.4, it 
 
 ## 1.3 Calibration strategy
 
-In `mlr3calibration`, to calibrate a learner you need a base learner (which will fit a model that is calibrated afterwards), a resampling strategy, and a calibration method (Platt, Beta or Isotonic). Initialize 1) another XGBOOST base learner, 2) a 5-fold CV resampling object, and 3) a calibration strategy. The calibration strategy in `mlr3calibration` is implemented as `PipeOpCalibrationPerFold` object. It requires the base learner (`learner`), the calibration method (`method`), and the resampling method (`rsmp`) as arguments to be initialized. Practically, we want to use the calibration strategy as learner, so we have to express the pipeline operator within `as_learner()`. After that, set `learner_cal$id <- "Platt Calibrated Learner"` for later reference.
+In `mlr3calibration`, to calibrate a learner you need a base learner (which will fit a model that is calibrated afterwards), a resampling strategy, and a calibration method (Platt, Beta or Isotonic). Initialize 1) another XGBOOST base learner, 2) a 5-fold CV resampling object, and 3) a calibration strategy. The calibration strategy in `mlr3calibration` is implemented as `PipeOpCalibrationPerFold` object. It requires the base learner (`learner`), the calibration method (`method`), and the resampling method (`resampling`) as arguments to be initialized. Practically, we want to use the calibration strategy as learner, so we have to express the pipeline operator within `as_learner()`. After that, set `learner_cal$id <- "Platt Calibrated Learner"` for later reference.
 
 <details>
 <summary>**Hint 1:**</summary>
@@ -154,7 +154,7 @@ Check the documentation of `PipeOpCalibrationPerFold` with `??PipeOpCalibrationP
 ```{r index-007}
 learner_uncal = lrn("classif.xgboost", predict_type = "prob")
 rsmp = rsmp("cv", folds = 5)
-learner_cal = as_learner(PipeOpCalibrationPerFold$new(learner = learner_uncal, method = "platt", rsmp = rsmp))
+learner_cal = as_learner(PipeOpCalibrationPerFold$new(learner = learner_uncal, method = "platt", resampling = rsmp))
 learner_cal$id <- "Platt Calibrated Learner"
 ```
 
@@ -255,7 +255,7 @@ calibrationplot(...)
 po_filter = po("filter", filter = flt("information_gain"), param_vals = list(filter.nfeat = 10L))
 pipeline = as_learner(po_filter %>>% lrn("classif.ranger", predict_type = "prob"))
 pipeline_cal = as_learner(PipeOpCalibrationPerFold$new(learner = pipeline,
-                                                rsmp = rsmp("cv", folds = 10),
+                                                resampling = rsmp("cv", folds = 10),
                                                 method = "beta"))
 pipeline_cal$id <- "Beta Calibrated Learner"
 pipeline_cal$train(task_train)

--- a/mlr-org/gallery/appliedml/2025-06-02-adv-perf-eval-calibration-mlr3/index.qmd
+++ b/mlr-org/gallery/appliedml/2025-06-02-adv-perf-eval-calibration-mlr3/index.qmd
@@ -124,7 +124,7 @@ The model is not well-calibrated. For predicted probabilities from 0 to 0.4, it 
 
 ## 1.3 Calibration strategy
 
-In `mlr3calibration`, to calibrate a learner you need a base learner (which will fit a model that is calibrated afterwards), a resampling strategy, and a calibration method (Platt, Beta or Isotonic). Initialize 1) another XGBOOST base learner, 2) a 5-fold CV resampling object, and 3) a calibration strategy. The calibration strategy in `mlr3calibration` is implemented as `PipeOpCalibration` object. It requires the base learner (`learner`), the calibration method (`method`), and the resampling method (`rsmp`) as arguments to be initialized. Practically, we want to use the calibration strategy as learner, so we have to express the pipeline operator within `as_learner()`. After that, set `learner_cal$id <- "Platt Calibrated Learner"` for later reference.
+In `mlr3calibration`, to calibrate a learner you need a base learner (which will fit a model that is calibrated afterwards), a resampling strategy, and a calibration method (Platt, Beta or Isotonic). Initialize 1) another XGBOOST base learner, 2) a 5-fold CV resampling object, and 3) a calibration strategy. The calibration strategy in `mlr3calibration` is implemented as `PipeOpCalibrationPerFold` object. It requires the base learner (`learner`), the calibration method (`method`), and the resampling method (`rsmp`) as arguments to be initialized. Practically, we want to use the calibration strategy as learner, so we have to express the pipeline operator within `as_learner()`. After that, set `learner_cal$id <- "Platt Calibrated Learner"` for later reference.
 
 <details>
 <summary>**Hint 1:**</summary>
@@ -132,7 +132,7 @@ In `mlr3calibration`, to calibrate a learner you need a base learner (which will
 ```{r index-006, eval = FALSE}
 learner_uncal = ...
 rsmp = ...
-learner_cal = as_learner(PipeOpCalibration$new(...))
+learner_cal = as_learner(PipeOpCalibrationPerFold$new(...))
 learner_cal$id <- "Platt Calibrated Learner"
 ```
 
@@ -141,7 +141,7 @@ learner_cal$id <- "Platt Calibrated Learner"
 <details>
 <summary>**Hint 2:**</summary>
 
-Check the documentation of `PipeOpCalibration` with `??PipeOpCalibration`.
+Check the documentation of `PipeOpCalibrationPerFold` with `??PipeOpCalibrationPerFold`.
 
 </details>
 
@@ -154,7 +154,7 @@ Check the documentation of `PipeOpCalibration` with `??PipeOpCalibration`.
 ```{r index-007}
 learner_uncal = lrn("classif.xgboost", predict_type = "prob")
 rsmp = rsmp("cv", folds = 5)
-learner_cal = as_learner(PipeOpCalibration$new(learner = learner_uncal, method = "platt", rsmp = rsmp))
+learner_cal = as_learner(PipeOpCalibrationPerFold$new(learner = learner_uncal, method = "platt", rsmp = rsmp))
 learner_cal$id <- "Platt Calibrated Learner"
 ```
 
@@ -224,7 +224,7 @@ The calibrated model has a much lower ECE. Therefore, we can infer that Platt sc
 
 # 3 Tuning and Pipelines
 
-`PipeOpCalibration` can be treated as any other `PipeOp` object. Therefore, we can use them within more complex tuning and pipeline constructs. There are many sensible options. For example, we could pass a tuned base learner to the calibrator or tune the base learner within the calibrator. Similarly, we can include a calibrated learner in a pipeline or choose to calibrate the entire pipeline. Let's try how to connect a feature filter to a calibrator. Construct a pipeline that 1) filters the 10 most relevant features according to their information gain, 2) then fits a random forest, and 3) calibrate this pipeline with beta calibration using 5-fold CV. Express this calibrated pipeline as learner, train it on the training task and plot the calibration plot with the Platt scaled and beta-calibrated models.
+`PipeOpCalibrationPerFold` can be treated as any other `PipeOp` object. Therefore, we can use them within more complex tuning and pipeline constructs. There are many sensible options. For example, we could pass a tuned base learner to the calibrator or tune the base learner within the calibrator. Similarly, we can include a calibrated learner in a pipeline or choose to calibrate the entire pipeline. Let's try how to connect a feature filter to a calibrator. Construct a pipeline that 1) filters the 10 most relevant features according to their information gain, 2) then fits a random forest, and 3) calibrate this pipeline with beta calibration using 5-fold CV. Express this calibrated pipeline as learner, train it on the training task and plot the calibration plot with the Platt scaled and beta-calibrated models.
 
 
 
@@ -236,7 +236,7 @@ You may use this skeleton code for the required steps.
 ```{r index-010, eval = FALSE}
 po_filter = po(...)
 pipeline = as_learner(... %>>% ...)
-pipeline_cal = as_learner(PipeOpCalibration$new(...))
+pipeline_cal = as_learner(PipeOpCalibrationPerFold$new(...))
 pipeline_cal$id <- "Beta Calibrated Learner"
 pipeline_cal$train(...)
 calibrationplot(...)
@@ -254,7 +254,7 @@ calibrationplot(...)
 #| eval: false
 po_filter = po("filter", filter = flt("information_gain"), param_vals = list(filter.nfeat = 10L))
 pipeline = as_learner(po_filter %>>% lrn("classif.ranger", predict_type = "prob"))
-pipeline_cal = as_learner(PipeOpCalibration$new(learner = pipeline,
+pipeline_cal = as_learner(PipeOpCalibrationPerFold$new(learner = pipeline,
                                                 rsmp = rsmp("cv", folds = 10),
                                                 method = "beta"))
 pipeline_cal$id <- "Beta Calibrated Learner"


### PR DESCRIPTION
## Summary
- The weekly gallery render ([run 24401918811](https://github.com/mlr-org/mlr3website/actions/runs/24401918811)) failed with `object 'PipeOpCalibration' not found`.
- Upstream [mlr3calibration](https://github.com/AdriGl117/mlr3calibration) renamed the class to `PipeOpCalibrationPerFold`; updates both calibration gallery posts to match.

## Test plan
- [ ] Weekly gallery render (`gallery-weekly`) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)